### PR TITLE
Added EventHandler and EventHandlerMut traits

### DIFF
--- a/examples/single_producer.rs
+++ b/examples/single_producer.rs
@@ -6,34 +6,46 @@ use log::*;
 
 const MAX: i64 = 200i64;
 
+struct Doubler;
+
+impl EventHandlerMut<u32> for Doubler {
+    fn handle_event(&mut self, data: &mut u32, sequence: Sequence, _: bool) {
+        let val = *data;
+        if i64::from(val) != sequence {
+            panic!(
+                "concurrency problem detected (p1), expected {}, but got {}",
+                sequence, val
+            );
+        }
+        debug!("updating sequence {} from {} to {}", sequence, val, val * 2);
+        *data = val * 2;
+    }
+}
+
+struct Checker;
+
+impl EventHandler<u32> for Checker {
+    fn handle_event(&mut self, data: &u32, sequence: Sequence, _: bool) {
+        let val = *data;
+        if i64::from(val) != sequence * 2 {
+            panic!(
+                "concurrency problem detected (p2), expected {}, but got {}",
+                sequence * 2,
+                val
+            );
+        }
+    }
+}
+
 fn follow_sequence<W: WaitStrategy + 'static>() {
     let (executor, producer) = DisrustorBuilder::with_ring_buffer(128)
         .with_wait_strategy::<W>()
         .with_single_producer()
         .with_barrier(|b| {
-            b.handle_events_mut(|data, sequence, _| {
-                let val = *data;
-                if i64::from(val) != sequence {
-                    panic!(
-                        "concurrency problem detected (p1), expected {}, but got {}",
-                        sequence, val
-                    );
-                }
-                debug!("updating sequence {} from {} to {}", sequence, val, val * 2);
-                *data = val * 2;
-            });
+            b.handle_events_mut(Doubler {});
         })
         .with_barrier(|b| {
-            b.handle_events(|data, sequence, _| {
-                let val = *data;
-                if i64::from(val) != sequence * 2 {
-                    panic!(
-                        "concurrency problem detected (p2), expected {}, but got {}",
-                        sequence * 2,
-                        val
-                    );
-                }
-            });
+            b.handle_events(Checker{});
         })
         .build();
 

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -143,14 +143,14 @@ impl<'a, S: Sequencer + 'a, W: WaitStrategy, D: DataProvider<T> + 'a, T: Send + 
 impl<'a, S: Sequencer + 'a, D: DataProvider<T> + 'a, T: Send + 'a> BarrierScope<'a, S, D, T> {
     pub fn handle_events<F>(&mut self, handler: F)
     where
-        F: Fn(&T, Sequence, bool) + Send + 'static,
+        F: EventHandler<T> + Send + 'a,
     {
         self.handle_events_with(BatchEventProcessor::create(handler))
     }
 
     pub fn handle_events_mut<F>(&mut self, handler: F)
     where
-        F: Fn(&mut T, Sequence, bool) + Send + 'static,
+        F: EventHandlerMut<T> + Send + 'a,
     {
         self.handle_events_with(BatchEventProcessor::create_mut(handler))
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -103,6 +103,14 @@ pub trait Runnable: Send {
     fn run(self: Box<Self>);
 }
 
+pub trait EventHandler<T> {
+    fn handle_event(&mut self, event: &T, seq: Sequence, eob: bool);
+}
+
+pub trait EventHandlerMut<T> {
+    fn handle_event(&mut self, event: &mut T, seq: Sequence, eob: bool);
+}
+
 pub trait EventProcessorExecutor<'a> {
     type Handle: ExecutorHandle;
     fn with_runnables(items: Vec<Box<dyn Runnable + 'a>>) -> Self;


### PR DESCRIPTION
This changes the API to take in types that implement the `EventHandler` and `EventHandlerMut` traits rather than standard `Fn`. 

This allows for functionality like:

```rust
use disrustor::{
    internal::SpinLoopWaitStrategy,
    *,
};

const MAX: i64 = 200i64;

struct Journal {
    pub i: u32,
    id: u32
}

impl Journal {
    fn new(id: u32) -> Self {
        Self {
            i: 0,
            id: id
        }
    }
}

impl EventHandler<u32> for Journal {
    fn handle_event(&mut self, event: &u32, seq: Sequence, eob: bool) {
        self.i = *event;
        println!(
            "journal: {}; msg: {}",
            self.id,
            self.i
        );
    }
}

fn main() {
    // let journal2 = std::cell::RefCell::new(Vec::<u32>::new()); // implemented somewhere else
    let (executor, producer) = DisrustorBuilder::with_ring_buffer(4096)
        .with_wait_strategy::<SpinLoopWaitStrategy>()
        .with_single_producer()
        .with_barrier(|b| {
            // journal + replication can happen in parallel
            b.handle_events(Journal::new(0));
            b.handle_events(Journal::new(1));
        })
        .build();

    let handle = executor.spawn();

    for i in 1..=MAX {
        std::thread::sleep_ms(1);
        producer.write([i], |d, _, _| {
            *d = i as u32;
        });
    }
    producer.drain();
    handle.join();
}
```

See #2 